### PR TITLE
docs: enhance security note for Supabase anon key exposure

### DIFF
--- a/src/services/supabase.js
+++ b/src/services/supabase.js
@@ -14,7 +14,7 @@ import { createClient } from '@supabase/supabase-js';
  * The anon key only allows access to data that RLS policies permit.
  * Without proper authentication and RLS policies, this key cannot access sensitive data.
  *
- * Learn more: https://supabase.com/docs/guides/auth/row-level-security
+ * Learn more: https://supabase.com/docs/guides/database/postgres/row-level-security
  */
 export const supabaseUrl = 'https://lhhmhrgrvalvdtbthxvu.supabase.co';
 const supabaseKey =

--- a/src/services/supabase.js
+++ b/src/services/supabase.js
@@ -1,4 +1,21 @@
 import { createClient } from '@supabase/supabase-js';
+
+/**
+ * SECURITY NOTE FOR REPOSITORY VIEWERS:
+ *
+ * The Supabase anon key below is intentionally public and safe to expose.
+ * This is the recommended approach by Supabase for client-side applications.
+ *
+ * Security is enforced through:
+ * - Row Level Security (RLS) policies on the database
+ * - User authentication and authorization
+ * - Server-side validation in Supabase
+ *
+ * The anon key only allows access to data that RLS policies permit.
+ * Without proper authentication and RLS policies, this key cannot access sensitive data.
+ *
+ * Learn more: https://supabase.com/docs/guides/auth/row-level-security
+ */
 export const supabaseUrl = 'https://lhhmhrgrvalvdtbthxvu.supabase.co';
 const supabaseKey =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImxoaG1ocmdydmFsdmR0YnRoeHZ1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3Mzk1NDA0OTIsImV4cCI6MjA1NTExNjQ5Mn0.EaxmzCOx5IHnIWO5JTbkCrWae4uKUNaSvntd5oo2Nfk';


### PR DESCRIPTION
This pull request adds a security note to the `src/services/supabase.js` file, clarifying that the Supabase anon key is intentionally public and safe for client-side use. No functional code changes were made; the update is purely for documentation and developer awareness.